### PR TITLE
fix: remove debug flag from plugin.json to prevent Decky UI crash

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Bluetooth",
   "author": "Outpox",
-  "flags": ["debug"],
+  "flags": [],
   "publish": {
     "tags": ["bluetooth", "utility"],
     "description": "Quickly connect to your already paired bluetooth devices.",


### PR DESCRIPTION
## Summary

- Remove `"flags": ["debug"]` from `plugin.json` (changed to `"flags": []`)
- This flag causes the plugin to be fully stopped and reloaded on every file-system event detected by Decky Loader's file watcher
- Combined with the `LEGACY_EVAL_IIFE` loading method, this creates a reload cascade that crashes the entire Decky Loader UI

## Problem

The `plugin.json` contains `"flags": ["debug"]`, which is intended for development only. When present in a release build, Decky Loader's `import_plugin` method will stop and reimport the plugin on every file change:

```python
if plugin.name in self.plugins:
    if not "debug" in plugin.flags and refresh:
        return  # skip reload — never reached with debug flag
    else:
        await self.plugins[plugin.name].stop()
        self.plugins.pop(plugin.name, None)
```

This is confirmed as the root cause in [decky-loader#903](https://github.com/SteamDeckHomebrew/decky-loader/issues/903) — multiple users confirmed that removing the Bluetooth plugin restores Decky UI.

## Fix

Simply clear the `flags` array in `plugin.json`. The `debug` flag should not be present in production releases.

## Additional Recommendations (out of scope for this PR)

- Migrate from `decky-frontend-lib` to `@decky/ui` + `@decky/api`
- Add `"api_version": 1` to `plugin.json`
- Add `"type": "module"` to `package.json` for ESMODULE_V1 loading